### PR TITLE
Add audio interrupt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ bash ~/.claude/scripts/tts-speak.sh "text to speak"
 \`\`\`
 The script handles chunking and seamless playback. Runs locally, free.
 
+**Stop playback**: When the user says "stop", "mute", or "quiet":
+\`\`\`bash
+bash ~/.claude/scripts/tts-stop.sh
+\`\`\`
+
 **Session voice toggle**: "voice on" / "voice off":
 \`\`\`bash
 export CLAUDE_TTS=auto   # auto-speak conversational responses
@@ -120,6 +125,18 @@ Tell Claude to read something:
 > "Say that"
 
 Claude pipes its response through TTS. Short responses play immediately; long responses are chunked with natural pacing — no gaps between sentences.
+
+### Stop playback
+
+Interrupt audio at any time:
+
+> "Stop"
+
+> "Mute"
+
+Or directly: `bash ~/.claude/scripts/tts-stop.sh`
+
+New audio automatically interrupts any currently playing audio — you don't need to stop manually before asking Claude to read something else.
 
 ### Voice sessions
 
@@ -272,7 +289,8 @@ claude-code-tts/
 │   ├── tts-speak.sh           # Claude Code Stop hook (auto-speak)
 │   └── tts-plan-reader.sh     # Plan approval auto-reader
 ├── scripts/
-│   └── tts-speak.sh           # On-demand "read that to me"
+│   ├── tts-speak.sh           # On-demand "read that to me"
+│   └── tts-stop.sh            # Stop current audio playback
 ├── install.sh                 # One-command installer (macOS + Linux)
 └── uninstall.sh               # Clean removal
 ```

--- a/hooks/tts-plan-reader.sh
+++ b/hooks/tts-plan-reader.sh
@@ -30,12 +30,15 @@ PLAN_FILE=$(ls -t "$PLAN_DIR"/*.md 2>/dev/null | head -1)
 TEXT=$(head -"$MAX_PLAN_LINES" "$PLAN_FILE" | cut -c1-"$MAX_PLAN_CHARS")
 [[ -z "$TEXT" ]] && exit 0
 
+# Stop any existing TTS playback
+pkill -f "ffplay.*claude-tts" 2>/dev/null
+
 (
     curl -s -X POST "$KOKORO_URL/speak" \
         -H "Content-Type: application/json" \
         -d "$(jq -n --arg text "$TEXT" '{text: $text}')" \
         --max-time 120 \
-        2>/dev/null | ffplay -nodisp -autoexit -loglevel quiet -i pipe:0 2>/dev/null
+        2>/dev/null | ffplay -nodisp -autoexit -loglevel quiet -f wav -window_title claude-tts -i pipe:0 2>/dev/null
 ) &
 
 exit 0

--- a/hooks/tts-speak.sh
+++ b/hooks/tts-speak.sh
@@ -49,13 +49,16 @@ curl -s --max-time 1 "$KOKORO_URL/health" >/dev/null 2>&1 || exit 0
 
 # --- Speak (async, don't block Claude) ---
 
+# Stop any existing TTS playback before starting new audio
+pkill -f "ffplay.*claude-tts" 2>/dev/null
+
 (
     echo $$ > "$LOCK_FILE"
     curl -s -X POST "$KOKORO_URL/speak" \
         -H "Content-Type: application/json" \
         -d "$(jq -n --arg text "$MESSAGE" '{text: $text, mode: "summary"}')" \
         --max-time 30 \
-        2>/dev/null | ffplay -nodisp -autoexit -loglevel quiet -i pipe:0 2>/dev/null
+        2>/dev/null | ffplay -nodisp -autoexit -loglevel quiet -f wav -window_title claude-tts -i pipe:0 2>/dev/null
     rm -f "$LOCK_FILE"
 ) &
 

--- a/install.sh
+++ b/install.sh
@@ -127,7 +127,8 @@ mkdir -p "$HOOKS_DIR" "$SCRIPTS_DIR"
 cp "$REPO_DIR/hooks/tts-speak.sh" "$HOOKS_DIR/tts-speak.sh"
 cp "$REPO_DIR/hooks/tts-plan-reader.sh" "$HOOKS_DIR/tts-plan-reader.sh"
 cp "$REPO_DIR/scripts/tts-speak.sh" "$SCRIPTS_DIR/tts-speak.sh"
-chmod +x "$HOOKS_DIR/tts-speak.sh" "$HOOKS_DIR/tts-plan-reader.sh" "$SCRIPTS_DIR/tts-speak.sh"
+cp "$REPO_DIR/scripts/tts-stop.sh" "$SCRIPTS_DIR/tts-stop.sh"
+chmod +x "$HOOKS_DIR/tts-speak.sh" "$HOOKS_DIR/tts-plan-reader.sh" "$SCRIPTS_DIR/tts-speak.sh" "$SCRIPTS_DIR/tts-stop.sh"
 echo "  Hooks and scripts installed."
 
 # --- Create daemon (platform-specific) ---

--- a/scripts/tts-speak.sh
+++ b/scripts/tts-speak.sh
@@ -26,12 +26,15 @@ if ! curl -s --max-time 2 "$KOKORO_URL/health" >/dev/null 2>&1; then
     exit 1
 fi
 
+# Stop any existing TTS playback
+pkill -f "ffplay.*claude-tts" 2>/dev/null
+
 echo "Speaking..."
 
 curl -s -X POST "$KOKORO_URL/speak" \
     -H "Content-Type: application/json" \
     -d "$(jq -n --arg text "$TEXT" '{text: $text}')" \
     --max-time 120 \
-    2>/dev/null | ffplay -nodisp -autoexit -loglevel quiet -i pipe:0 2>/dev/null
+    2>/dev/null | ffplay -nodisp -autoexit -loglevel quiet -f wav -window_title claude-tts -i pipe:0 2>/dev/null
 
 echo "Done."

--- a/scripts/tts-stop.sh
+++ b/scripts/tts-stop.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Stop any currently playing TTS audio.
+# Can be called manually, via hotkey, or by Claude ("stop", "mute").
+#
+# Usage: tts-stop.sh
+
+if pkill -f "ffplay.*claude-tts" 2>/dev/null; then
+    echo "Stopped."
+else
+    echo "Nothing playing."
+fi
+
+# Clean up stale lock file
+rm -f /tmp/claude-tts.lock


### PR DESCRIPTION
## Summary
- New `scripts/tts-stop.sh` — kills active TTS playback via `pkill`
- All playback scripts auto-interrupt existing audio before starting new playback
- Uses `ffplay -window_title claude-tts` as a unique process signature for targeted kill
- README and installer updated

## Test plan
- [x] Start long audio, run `tts-stop.sh` mid-playback — audio stops
- [x] Start audio, then "read that to me" again — old audio stops, new starts
- [x] Run `tts-stop.sh` with nothing playing — prints "Nothing playing"

Closes #1