### PR TITLE
Add terminal word highlighting (karaoke mode)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -139,7 +139,8 @@ cp "$REPO_DIR/scripts/tts-speak.sh" "$SCRIPTS_DIR/tts-speak.sh"
 cp "$REPO_DIR/scripts/tts-stop.sh" "$SCRIPTS_DIR/tts-stop.sh"
 cp "$REPO_DIR/scripts/tts-chime.sh" "$SCRIPTS_DIR/tts-chime.sh"
 cp "$REPO_DIR/scripts/tts-log.sh" "$SCRIPTS_DIR/tts-log.sh"
-chmod +x "$HOOKS_DIR/tts-speak.sh" "$HOOKS_DIR/tts-plan-reader.sh" "$HOOKS_DIR/tts-workflow.sh" "$SCRIPTS_DIR/tts-speak.sh" "$SCRIPTS_DIR/tts-stop.sh" "$SCRIPTS_DIR/tts-chime.sh" "$SCRIPTS_DIR/tts-log.sh"
+cp "$REPO_DIR/scripts/tts-karaoke.sh" "$SCRIPTS_DIR/tts-karaoke.sh"
+chmod +x "$HOOKS_DIR/tts-speak.sh" "$HOOKS_DIR/tts-plan-reader.sh" "$HOOKS_DIR/tts-workflow.sh" "$SCRIPTS_DIR/tts-speak.sh" "$SCRIPTS_DIR/tts-stop.sh" "$SCRIPTS_DIR/tts-chime.sh" "$SCRIPTS_DIR/tts-log.sh" "$SCRIPTS_DIR/tts-karaoke.sh"
 echo "  Hooks and scripts installed."
 
 # --- Create daemon (platform-specific) ---

--- a/install.sh
+++ b/install.sh
@@ -140,7 +140,8 @@ cp "$REPO_DIR/scripts/tts-stop.sh" "$SCRIPTS_DIR/tts-stop.sh"
 cp "$REPO_DIR/scripts/tts-chime.sh" "$SCRIPTS_DIR/tts-chime.sh"
 cp "$REPO_DIR/scripts/tts-log.sh" "$SCRIPTS_DIR/tts-log.sh"
 cp "$REPO_DIR/scripts/tts-karaoke.sh" "$SCRIPTS_DIR/tts-karaoke.sh"
-chmod +x "$HOOKS_DIR/tts-speak.sh" "$HOOKS_DIR/tts-plan-reader.sh" "$HOOKS_DIR/tts-workflow.sh" "$SCRIPTS_DIR/tts-speak.sh" "$SCRIPTS_DIR/tts-stop.sh" "$SCRIPTS_DIR/tts-chime.sh" "$SCRIPTS_DIR/tts-log.sh" "$SCRIPTS_DIR/tts-karaoke.sh"
+cp "$REPO_DIR/scripts/karaoke_display.py" "$SCRIPTS_DIR/karaoke_display.py"
+chmod +x "$HOOKS_DIR/tts-speak.sh" "$HOOKS_DIR/tts-plan-reader.sh" "$HOOKS_DIR/tts-workflow.sh" "$SCRIPTS_DIR/tts-speak.sh" "$SCRIPTS_DIR/tts-stop.sh" "$SCRIPTS_DIR/tts-chime.sh" "$SCRIPTS_DIR/tts-log.sh" "$SCRIPTS_DIR/tts-karaoke.sh" "$SCRIPTS_DIR/karaoke_display.py"
 echo "  Hooks and scripts installed."
 
 # --- Create daemon (platform-specific) ---

--- a/scripts/karaoke_display.py
+++ b/scripts/karaoke_display.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Karaoke display engine — word-by-word terminal highlighting synchronized to TTS audio.
+
+Reads display text from stdin. Duration passed via --duration flag.
+Uses only Python stdlib (no external dependencies).
+
+Usage:
+    echo "text to highlight" | python3 karaoke_display.py --duration 4.5
+"""
+
+import argparse
+import atexit
+import shutil
+import signal
+import sys
+import time
+
+# ANSI escape sequences
+DIM = "\033[2m"
+BOLD_CYAN = "\033[1;36m"
+RESET = "\033[0m"
+HIDE_CURSOR = "\033[?25l"
+SHOW_CURSOR = "\033[?25h"
+CLEAR_LINE = "\r\033[K"
+
+# Minimum seconds any single word can occupy (prevents zero-width flicker)
+MIN_WORD_DURATION = 0.08
+# Minimum character weight per word (so "I" and "a" still get some time)
+MIN_CHAR_WEIGHT = 2
+# Display refresh interval in seconds (~33 fps)
+REFRESH_INTERVAL = 0.03
+
+# Output target — /dev/tty bypasses stdout redirection (works under MCP)
+_tty = None
+
+
+def _get_output():
+    """Open /dev/tty for direct terminal output, fall back to stderr."""
+    global _tty
+    if _tty is not None:
+        return _tty
+    try:
+        _tty = open("/dev/tty", "w")
+    except OSError:
+        _tty = sys.stderr
+    return _tty
+
+
+def _write(text):
+    """Write text to the terminal output."""
+    out = _get_output()
+    out.write(text)
+    out.flush()
+
+
+def _cleanup(sig=None, frame=None):
+    """Reset terminal state: show cursor, clear ANSI attributes."""
+    try:
+        _write(SHOW_CURSOR + RESET + "\n")
+        if _tty is not None and _tty is not sys.stderr:
+            _tty.close()
+    except Exception:
+        pass
+    if sig is not None:
+        sys.exit(0)
+
+
+def compute_word_timings(words, total_duration):
+    """Return per-word durations proportional to character count.
+
+    Longer words get more time. Each word has a minimum character weight
+    of MIN_CHAR_WEIGHT so short words ("I", "a") still get some time.
+    Per-word duration is floored at MIN_WORD_DURATION seconds.
+    The sum of returned durations always equals total_duration.
+    """
+    if not words:
+        return []
+    if total_duration <= 0:
+        return [0.0] * len(words)
+
+    n = len(words)
+    char_weights = [max(len(w), MIN_CHAR_WEIGHT) for w in words]
+    total_weight = sum(char_weights)
+
+    # Initial proportional allocation
+    timings = [(w / total_weight) * total_duration for w in char_weights]
+
+    # Enforce minimum duration floor
+    deficit = 0.0
+    unclamped_weight = 0.0
+    for i, t in enumerate(timings):
+        if t < MIN_WORD_DURATION:
+            deficit += MIN_WORD_DURATION - t
+            timings[i] = MIN_WORD_DURATION
+        else:
+            unclamped_weight += char_weights[i]
+
+    # Redistribute deficit from unclamped words proportionally
+    if deficit > 0 and unclamped_weight > 0:
+        for i in range(n):
+            if timings[i] > MIN_WORD_DURATION:
+                reduction = deficit * (char_weights[i] / unclamped_weight)
+                timings[i] -= reduction
+
+    # Fix floating-point drift so sum exactly equals total_duration
+    drift = total_duration - sum(timings)
+    if timings:
+        timings[-1] += drift
+
+    return timings
+
+
+def render_line(words, current_idx, term_width):
+    """Build one ANSI-formatted line showing a sliding window of words.
+
+    - Words before current_idx: dim
+    - Word at current_idx: bold cyan
+    - Words after current_idx: default
+    - Sliding window centered on current word, fits within term_width
+    - Appends progress: [42%] in dim
+    """
+    n = len(words)
+    progress = f" {DIM}[{(current_idx + 1) * 100 // n}%]{RESET}"
+    # Reserve space for progress indicator (strip ANSI for width calc)
+    progress_width = len(f" [{(current_idx + 1) * 100 // n}%]")
+    available = term_width - progress_width - 2  # margin
+
+    # Expand window around current_idx to fill available width
+    left = current_idx
+    right = current_idx
+    width = len(words[current_idx])
+
+    while True:
+        expanded = False
+        # Try expanding left
+        if left > 0 and width + len(words[left - 1]) + 1 <= available:
+            left -= 1
+            width += len(words[left]) + 1
+            expanded = True
+        # Try expanding right
+        if right < n - 1 and width + len(words[right + 1]) + 1 <= available:
+            right += 1
+            width += len(words[right]) + 1
+            expanded = True
+        if not expanded:
+            break
+
+    # Build the formatted line
+    parts = []
+    for i in range(left, right + 1):
+        if i < current_idx:
+            parts.append(f"{DIM}{words[i]}{RESET}")
+        elif i == current_idx:
+            parts.append(f"{BOLD_CYAN}{words[i]}{RESET}")
+        else:
+            parts.append(words[i])
+
+    return CLEAR_LINE + " ".join(parts) + progress
+
+
+def run(words, timings):
+    """Main display loop. Blocks until all words are shown."""
+    n = len(words)
+    term_width = shutil.get_terminal_size().columns
+
+    word_idx = 0
+    # Cumulative timestamps: word i ends at cumulative[i]
+    cumulative = []
+    acc = 0.0
+    for t in timings:
+        acc += t
+        cumulative.append(acc)
+
+    t0 = time.monotonic()
+
+    while word_idx < n:
+        elapsed = time.monotonic() - t0
+
+        # Advance to the correct word based on elapsed time
+        while word_idx < n - 1 and elapsed >= cumulative[word_idx]:
+            word_idx += 1
+
+        _write(render_line(words, word_idx, term_width))
+        time.sleep(REFRESH_INTERVAL)
+
+    # Show final state briefly
+    _write(render_line(words, n - 1, term_width))
+    time.sleep(0.2)
+    _write(CLEAR_LINE)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Karaoke word-highlighting display")
+    parser.add_argument("--duration", type=float, required=True, help="Audio duration in seconds")
+    parser.add_argument("--width", type=int, default=0, help="Override terminal width")
+    args = parser.parse_args()
+
+    text = sys.stdin.read().strip()
+    if not text:
+        sys.exit(0)
+
+    words = text.split()
+    if not words:
+        sys.exit(0)
+
+    timings = compute_word_timings(words, args.duration)
+
+    signal.signal(signal.SIGINT, _cleanup)
+    signal.signal(signal.SIGTERM, _cleanup)
+    atexit.register(_cleanup)
+
+    _write(HIDE_CURSOR)
+    run(words, timings)
+    _cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tts-karaoke.sh
+++ b/scripts/tts-karaoke.sh
@@ -1,14 +1,24 @@
 #!/bin/bash
-# Karaoke mode — speak text with word-by-word terminal highlighting.
+# Karaoke mode — display text for reading while audio plays in background.
 #
 # Usage: tts-karaoke.sh "text to speak"
 #    or: echo "text" | tts-karaoke.sh
 #
-# Shows the currently spoken word highlighted in the terminal,
-# advancing in sync with audio playback.
+# Prints the text so the user can read along while hearing it spoken.
+# In a real terminal, adds word-by-word ANSI highlighting (--animate flag).
 
 KOKORO_URL="http://127.0.0.1:${KOKORO_PORT:-7723}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DISPLAY_SCRIPT="$SCRIPT_DIR/karaoke_display.py"
+HEADER_FILE="/tmp/claude-tts-karaoke-headers.txt"
 AUDIO_FILE="/tmp/claude-tts-karaoke.wav"
+
+# Parse flags
+ANIMATE=false
+if [[ "$1" == "--animate" ]]; then
+    ANIMATE=true
+    shift
+fi
 
 # Get text from argument or stdin
 if [[ -n "$1" ]]; then
@@ -28,91 +38,48 @@ fi
 # Stop existing playback
 pkill -f "ffplay.*claude-tts" 2>/dev/null
 
-# Generate audio and save to file (need duration info)
-HTTP_CODE=$(curl -s -o "$AUDIO_FILE" -w '%{http_code}' -X POST "$KOKORO_URL/speak" \
+# Cleanup on exit
+FFPLAY_PID=""
+cleanup() {
+    [[ -n "$FFPLAY_PID" ]] && kill "$FFPLAY_PID" 2>/dev/null
+    rm -f "$HEADER_FILE" "$AUDIO_FILE"
+}
+trap cleanup EXIT
+
+# Generate audio — save WAV + response headers
+HTTP_CODE=$(curl -s -o "$AUDIO_FILE" -D "$HEADER_FILE" -w '%{http_code}' \
+    -X POST "$KOKORO_URL/speak" \
     -H "Content-Type: application/json" \
     -d "$(jq -n --arg text "$TEXT" '{text: $text}')" \
     --max-time 30 2>/dev/null)
 
 [[ "$HTTP_CODE" != "200" || ! -s "$AUDIO_FILE" ]] && { echo "TTS generation failed"; exit 1; }
 
-# Get audio duration in seconds using ffprobe
-DURATION=$(ffprobe -v quiet -show_entries format=duration -of csv=p=0 "$AUDIO_FILE" 2>/dev/null)
-[[ -z "$DURATION" ]] && { echo "Could not determine audio duration"; exit 1; }
+DURATION=$(grep -i "X-TTS-Duration:" "$HEADER_FILE" | tr -d '\r' | awk '{print $2}')
 
-# Preprocess text for display (strip markdown simply)
-DISPLAY_TEXT=$(echo "$TEXT" | sed 's/```[^`]*```//g; s/`[^`]*`//g; s/\*\*\([^*]*\)\*\*/\1/g; s/\*\([^*]*\)\*/\1/g; s/^#* //; s/^[-*] //')
-
-# Split into words
-IFS=' ' read -ra WORDS <<< "$DISPLAY_TEXT"
-WORD_COUNT=${#WORDS[@]}
-
-[[ "$WORD_COUNT" -eq 0 ]] && exit 0
-
-# Calculate time per word (seconds, as float via awk)
-TIME_PER_WORD=$(awk "BEGIN {printf \"%.4f\", $DURATION / $WORD_COUNT}")
-
-# ANSI escape codes
-BOLD='\033[1m'
-DIM='\033[2m'
-UNDERLINE='\033[4m'
-HIGHLIGHT='\033[1;36m'  # bold cyan
-RESET='\033[0m'
-
-# Start audio playback in background
+# Play audio in background
 ffplay -nodisp -autoexit -loglevel quiet -window_title claude-tts "$AUDIO_FILE" 2>/dev/null &
 FFPLAY_PID=$!
 
-# Hide cursor
-printf '\033[?25l'
+# Strip markdown for display
+DISPLAY_TEXT=$(echo "$TEXT" | sed '
+    s/```[^`]*```//g
+    s/`[^`]*`//g
+    s/\*\*\([^*]*\)\*\*/\1/g
+    s/\*\([^*]*\)\*/\1/g
+    s/^#* //
+    s/^[-*] //
+')
 
-# Cleanup on exit
-cleanup() {
-    printf '\033[?25h'  # show cursor
+# Display text — animated ANSI in terminal, plain text otherwise
+if [[ "$ANIMATE" == "true" ]] && [[ -n "$DURATION" ]] && [[ -e /dev/tty ]] && python3 -c "open('/dev/tty','w')" 2>/dev/null; then
+    echo "$DISPLAY_TEXT" | python3 "$DISPLAY_SCRIPT" --duration "$DURATION"
+else
     echo ""
-    rm -f "$AUDIO_FILE"
-}
-trap cleanup EXIT
-
-# Display words with highlighting
-START_TIME=$(date +%s.%N 2>/dev/null || python3 -c "import time; print(f'{time.time():.6f}')")
-
-for i in "${!WORDS[@]}"; do
-    # Check if ffplay is still running
-    if ! kill -0 "$FFPLAY_PID" 2>/dev/null; then
-        break
-    fi
-
-    # Clear line and render: dim past words, highlight current, dim future
-    printf '\r\033[K'
-
-    # Show a window of words around the current one (±8 words)
-    WINDOW_START=$((i - 8))
-    WINDOW_END=$((i + 8))
-    [[ $WINDOW_START -lt 0 ]] && WINDOW_START=0
-    [[ $WINDOW_END -ge $WORD_COUNT ]] && WINDOW_END=$((WORD_COUNT - 1))
-
-    for j in $(seq "$WINDOW_START" "$WINDOW_END"); do
-        if [[ $j -lt $i ]]; then
-            printf "${DIM}%s${RESET} " "${WORDS[$j]}"
-        elif [[ $j -eq $i ]]; then
-            printf "${HIGHLIGHT}%s${RESET} " "${WORDS[$j]}"
-        else
-            printf "%s " "${WORDS[$j]}"
-        fi
-    done
-
-    # Progress indicator
-    PROGRESS=$(( (i + 1) * 100 / WORD_COUNT ))
-    printf "  ${DIM}[%d%%]${RESET}" "$PROGRESS"
-
-    # Wait for next word timing
-    # Use python for sub-second sleep since bash sleep only does integers on some systems
-    python3 -c "import time; time.sleep($TIME_PER_WORD)" 2>/dev/null || sleep 1
-done
+    echo "$DISPLAY_TEXT"
+    echo ""
+fi
 
 # Wait for audio to finish
 wait "$FFPLAY_PID" 2>/dev/null
-
-printf '\r\033[K'
-echo "Done."
+FFPLAY_PID=""

--- a/scripts/tts-karaoke.sh
+++ b/scripts/tts-karaoke.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Karaoke mode — speak text with word-by-word terminal highlighting.
+#
+# Usage: tts-karaoke.sh "text to speak"
+#    or: echo "text" | tts-karaoke.sh
+#
+# Shows the currently spoken word highlighted in the terminal,
+# advancing in sync with audio playback.
+
+KOKORO_URL="http://127.0.0.1:${KOKORO_PORT:-7723}"
+AUDIO_FILE="/tmp/claude-tts-karaoke.wav"
+
+# Get text from argument or stdin
+if [[ -n "$1" ]]; then
+    TEXT="$1"
+else
+    TEXT=$(cat)
+fi
+
+[[ -z "$TEXT" ]] && { echo "No text provided"; exit 1; }
+
+# Check daemon
+if ! curl -s --max-time 2 "$KOKORO_URL/health" >/dev/null 2>&1; then
+    echo "Kokoro daemon not running."
+    exit 1
+fi
+
+# Stop existing playback
+pkill -f "ffplay.*claude-tts" 2>/dev/null
+
+# Generate audio and save to file (need duration info)
+HTTP_CODE=$(curl -s -o "$AUDIO_FILE" -w '%{http_code}' -X POST "$KOKORO_URL/speak" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n --arg text "$TEXT" '{text: $text}')" \
+    --max-time 30 2>/dev/null)
+
+[[ "$HTTP_CODE" != "200" || ! -s "$AUDIO_FILE" ]] && { echo "TTS generation failed"; exit 1; }
+
+# Get audio duration in seconds using ffprobe
+DURATION=$(ffprobe -v quiet -show_entries format=duration -of csv=p=0 "$AUDIO_FILE" 2>/dev/null)
+[[ -z "$DURATION" ]] && { echo "Could not determine audio duration"; exit 1; }
+
+# Preprocess text for display (strip markdown simply)
+DISPLAY_TEXT=$(echo "$TEXT" | sed 's/```[^`]*```//g; s/`[^`]*`//g; s/\*\*\([^*]*\)\*\*/\1/g; s/\*\([^*]*\)\*/\1/g; s/^#* //; s/^[-*] //')
+
+# Split into words
+IFS=' ' read -ra WORDS <<< "$DISPLAY_TEXT"
+WORD_COUNT=${#WORDS[@]}
+
+[[ "$WORD_COUNT" -eq 0 ]] && exit 0
+
+# Calculate time per word (seconds, as float via awk)
+TIME_PER_WORD=$(awk "BEGIN {printf \"%.4f\", $DURATION / $WORD_COUNT}")
+
+# ANSI escape codes
+BOLD='\033[1m'
+DIM='\033[2m'
+UNDERLINE='\033[4m'
+HIGHLIGHT='\033[1;36m'  # bold cyan
+RESET='\033[0m'
+
+# Start audio playback in background
+ffplay -nodisp -autoexit -loglevel quiet -window_title claude-tts "$AUDIO_FILE" 2>/dev/null &
+FFPLAY_PID=$!
+
+# Hide cursor
+printf '\033[?25l'
+
+# Cleanup on exit
+cleanup() {
+    printf '\033[?25h'  # show cursor
+    echo ""
+    rm -f "$AUDIO_FILE"
+}
+trap cleanup EXIT
+
+# Display words with highlighting
+START_TIME=$(date +%s.%N 2>/dev/null || python3 -c "import time; print(f'{time.time():.6f}')")
+
+for i in "${!WORDS[@]}"; do
+    # Check if ffplay is still running
+    if ! kill -0 "$FFPLAY_PID" 2>/dev/null; then
+        break
+    fi
+
+    # Clear line and render: dim past words, highlight current, dim future
+    printf '\r\033[K'
+
+    # Show a window of words around the current one (±8 words)
+    WINDOW_START=$((i - 8))
+    WINDOW_END=$((i + 8))
+    [[ $WINDOW_START -lt 0 ]] && WINDOW_START=0
+    [[ $WINDOW_END -ge $WORD_COUNT ]] && WINDOW_END=$((WORD_COUNT - 1))
+
+    for j in $(seq "$WINDOW_START" "$WINDOW_END"); do
+        if [[ $j -lt $i ]]; then
+            printf "${DIM}%s${RESET} " "${WORDS[$j]}"
+        elif [[ $j -eq $i ]]; then
+            printf "${HIGHLIGHT}%s${RESET} " "${WORDS[$j]}"
+        else
+            printf "%s " "${WORDS[$j]}"
+        fi
+    done
+
+    # Progress indicator
+    PROGRESS=$(( (i + 1) * 100 / WORD_COUNT ))
+    printf "  ${DIM}[%d%%]${RESET}" "$PROGRESS"
+
+    # Wait for next word timing
+    # Use python for sub-second sleep since bash sleep only does integers on some systems
+    python3 -c "import time; time.sleep($TIME_PER_WORD)" 2>/dev/null || sleep 1
+done
+
+# Wait for audio to finish
+wait "$FFPLAY_PID" 2>/dev/null
+
+printf '\r\033[K'
+echo "Done."

--- a/server/kokoro-server.py
+++ b/server/kokoro-server.py
@@ -106,6 +106,7 @@ class TTSHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "audio/wav")
         self.send_header("Content-Length", str(len(wav_bytes)))
+        self.send_header("X-TTS-Duration", f"{len(samples) / sample_rate:.3f}")
         if tone:
             self.send_header("X-TTS-Tone", tone)
         self.end_headers()

--- a/server/mcp-server.py
+++ b/server/mcp-server.py
@@ -116,17 +116,16 @@ def _speak(text, voice=None, speed=None, mode=None, agent=None):
 
 
 def _speak_karaoke(text):
-    """Launch the karaoke script for word-highlighted playback."""
-    karaoke_script = os.path.join(os.path.expanduser("~"), ".claude", "scripts", "tts-karaoke.sh")
-    if not os.path.isfile(karaoke_script):
-        return {"success": False, "error": "tts-karaoke.sh not found. Run install.sh first."}
+    """Speak text and return it for display — user reads along while hearing it.
 
-    subprocess.Popen(
-        ["bash", karaoke_script, text],
-        stdout=None, stderr=None,
-        start_new_session=True,
-    )
-    return {"success": True, "mode": "karaoke"}
+    Plays audio non-blocking (like regular speak), returns the text so
+    Claude can display it inline.
+    """
+    result = _speak(text)
+    if result.get("success") and result.get("spoken"):
+        result["display_text"] = text
+        result["mode"] = "karaoke"
+    return result
 
 
 def _stop():

--- a/server/mcp-server.py
+++ b/server/mcp-server.py
@@ -115,6 +115,20 @@ def _speak(text, voice=None, speed=None, mode=None, agent=None):
         return {"success": False, "error": str(e)}
 
 
+def _speak_karaoke(text):
+    """Launch the karaoke script for word-highlighted playback."""
+    karaoke_script = os.path.join(os.path.expanduser("~"), ".claude", "scripts", "tts-karaoke.sh")
+    if not os.path.isfile(karaoke_script):
+        return {"success": False, "error": "tts-karaoke.sh not found. Run install.sh first."}
+
+    subprocess.Popen(
+        ["bash", karaoke_script, text],
+        stdout=None, stderr=None,
+        start_new_session=True,
+    )
+    return {"success": True, "mode": "karaoke"}
+
+
 def _stop():
     """Stop any currently playing TTS audio."""
     result = subprocess.run(["pkill", "-f", "ffplay.*claude-tts"], capture_output=True)
@@ -163,6 +177,24 @@ TOOLS = [
         },
     },
     {
+        "name": "speak_karaoke",
+        "description": (
+            "Speak text with karaoke-style word highlighting in the terminal. "
+            "Shows the currently spoken word highlighted, advancing in sync with audio. "
+            "Use for longer explanations where visual tracking helps."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The text to speak with karaoke display.",
+                },
+            },
+            "required": ["text"],
+        },
+    },
+    {
         "name": "stop",
         "description": "Stop any currently playing TTS audio immediately.",
         "inputSchema": {"type": "object", "properties": {}},
@@ -196,6 +228,8 @@ def handle_request(msg):
 
         if tool_name == "speak":
             result = _speak(args.get("text", ""), args.get("voice"), args.get("speed"), agent=args.get("agent"))
+        elif tool_name == "speak_karaoke":
+            result = _speak_karaoke(args.get("text", ""))
         elif tool_name == "stop":
             result = _stop()
         elif tool_name == "status":

--- a/tests/test_karaoke.py
+++ b/tests/test_karaoke.py
@@ -1,0 +1,121 @@
+"""Tests for the karaoke display engine."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from karaoke_display import compute_word_timings, render_line
+
+
+# ---------------------------------------------------------------------------
+# compute_word_timings
+# ---------------------------------------------------------------------------
+
+
+class TestComputeWordTimings:
+    def test_proportional_to_length(self):
+        words = ["I", "fundamentally", "agree"]
+        timings = compute_word_timings(words, 3.0)
+        assert timings[1] > timings[0]
+        assert timings[1] > timings[2]
+
+    def test_sums_to_total(self):
+        words = ["Hello", "world", "this", "is", "a", "test"]
+        timings = compute_word_timings(words, 5.0)
+        assert abs(sum(timings) - 5.0) < 0.001
+
+    def test_single_word(self):
+        timings = compute_word_timings(["Hello"], 2.0)
+        assert len(timings) == 1
+        assert abs(timings[0] - 2.0) < 0.001
+
+    def test_minimum_duration_floor(self):
+        words = ["I", "a", "supercalifragilisticexpialidocious"]
+        timings = compute_word_timings(words, 3.0)
+        assert timings[0] >= 0.08
+        assert timings[1] >= 0.08
+
+    def test_empty_input(self):
+        assert compute_word_timings([], 5.0) == []
+
+    def test_zero_duration(self):
+        timings = compute_word_timings(["Hello", "world"], 0.0)
+        assert all(t == 0.0 for t in timings)
+
+    def test_equal_length_words_get_equal_time(self):
+        words = ["aaa"] * 10
+        timings = compute_word_timings(words, 10.0)
+        assert abs(timings[0] - timings[5]) < 0.001
+        assert abs(sum(timings) - 10.0) < 0.001
+
+    def test_longest_word_gets_most_time(self):
+        words = "The API uses JWT tokens for authentication".split()
+        timings = compute_word_timings(words, 4.0)
+        assert len(timings) == 7
+        assert abs(sum(timings) - 4.0) < 0.001
+        # "authentication" (14 chars) should get the most time
+        assert timings[6] == max(timings)
+
+    def test_short_words_use_minimum_weight(self):
+        # "I" (1 char) and "is" (2 chars) should get the same weight
+        # because both are at or below MIN_CHAR_WEIGHT of 2
+        words = ["I", "is", "extraordinary"]
+        timings = compute_word_timings(words, 3.0)
+        assert abs(timings[0] - timings[1]) < 0.001
+
+    def test_many_words(self):
+        words = ["word"] * 100
+        timings = compute_word_timings(words, 20.0)
+        assert len(timings) == 100
+        assert abs(sum(timings) - 20.0) < 0.001
+
+
+# ---------------------------------------------------------------------------
+# render_line
+# ---------------------------------------------------------------------------
+
+
+class TestRenderLine:
+    def test_current_word_highlighted(self):
+        words = ["Hello", "world", "test"]
+        line = render_line(words, 1, 80)
+        assert "\033[1;36mworld\033[0m" in line
+
+    def test_past_words_dimmed(self):
+        words = ["Hello", "world", "test"]
+        line = render_line(words, 2, 80)
+        assert "\033[2m" in line
+
+    def test_progress_shown(self):
+        words = ["Hello", "world"]
+        line = render_line(words, 0, 80)
+        assert "%" in line
+
+    def test_first_word(self):
+        words = ["Hello", "world"]
+        line = render_line(words, 0, 80)
+        assert "\033[1;36mHello\033[0m" in line
+
+    def test_last_word(self):
+        words = ["Hello", "world"]
+        line = render_line(words, 1, 80)
+        assert "\033[1;36mworld\033[0m" in line
+
+    def test_narrow_terminal_does_not_crash(self):
+        words = "This is a very long sentence with many words".split()
+        line = render_line(words, 5, 30)
+        assert len(line) > 0
+
+    def test_single_word(self):
+        words = ["Hello"]
+        line = render_line(words, 0, 80)
+        assert "\033[1;36mHello\033[0m" in line
+        assert "100%" in line
+
+    def test_progress_increases(self):
+        words = ["one", "two", "three", "four"]
+        line_start = render_line(words, 0, 80)
+        line_end = render_line(words, 3, 80)
+        assert "25%" in line_start
+        assert "100%" in line_end

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -60,7 +60,8 @@ for f in "$HOME/.claude/hooks/tts-speak.sh" \
          "$HOME/.claude/hooks/tts-workflow.sh" \
          "$HOME/.claude/scripts/tts-speak.sh" \
          "$HOME/.claude/scripts/tts-chime.sh" \
-         "$HOME/.claude/scripts/tts-log.sh"; do
+         "$HOME/.claude/scripts/tts-log.sh" \
+         "$HOME/.claude/scripts/tts-karaoke.sh"; do
     if [[ -f "$f" ]]; then
         rm "$f"
         echo "  Removed $f"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -61,7 +61,8 @@ for f in "$HOME/.claude/hooks/tts-speak.sh" \
          "$HOME/.claude/scripts/tts-speak.sh" \
          "$HOME/.claude/scripts/tts-chime.sh" \
          "$HOME/.claude/scripts/tts-log.sh" \
-         "$HOME/.claude/scripts/tts-karaoke.sh"; do
+         "$HOME/.claude/scripts/tts-karaoke.sh" \
+         "$HOME/.claude/scripts/karaoke_display.py"; do
     if [[ -f "$f" ]]; then
         rm "$f"
         echo "  Removed $f"


### PR DESCRIPTION
## Summary
- Rewrites karaoke mode with a Python display engine replacing the all-bash implementation
- Proportional word timing by character count (longer words get more time) instead of uniform timing
- Adds `X-TTS-Duration` response header to the server — clients no longer need ffprobe
- Default mode: prints text for the user to read while audio plays in background — works everywhere including Claude Code
- ANSI terminal animation available via `--animate` flag for direct terminal use
- MCP `speak_karaoke` tool reuses the speak pipeline and returns display text inline
- 18 new unit tests for timing calculation and rendering

## Test plan
- [x] `python3 -m pytest tests/ -v` — 104 tests passing
- [x] `bash scripts/tts-karaoke.sh "test text"` — prints text, plays audio
- [x] `curl -D- ... | grep X-TTS-Duration` — header present with correct value
- [x] ExitPlanMode hook speaks plan file
- [ ] `bash scripts/tts-karaoke.sh --animate "test text"` — ANSI highlighting in real terminal

Closes #12